### PR TITLE
ISSUE-3 - Move path and root path combination to the manager level

### DIFF
--- a/src/Baseline.Filesystem.Adapters.S3/S3Adapter.Directory.cs
+++ b/src/Baseline.Filesystem.Adapters.S3/S3Adapter.Directory.cs
@@ -128,12 +128,7 @@ namespace Baseline.Filesystem.Adapters.S3
             CancellationToken cancellationToken
         )
         {
-            var directoryExists = await DirectoryExistsAsync(
-                directoryPath,
-                cancellationToken
-            ).ConfigureAwait(false);
-
-            if (directoryExists)
+            if (await DirectoryExistsAsync(directoryPath, cancellationToken).ConfigureAwait(false))
             {
                 throw new DirectoryAlreadyExistsException(directoryPath.NormalisedPath);
             }
@@ -149,12 +144,7 @@ namespace Baseline.Filesystem.Adapters.S3
             CancellationToken cancellationToken
         )
         {
-            var directoryExists = await DirectoryExistsAsync(
-                directoryPath,
-                cancellationToken
-            ).ConfigureAwait(false);
-            
-            if (!directoryExists)
+            if (!await DirectoryExistsAsync(directoryPath, cancellationToken).ConfigureAwait(false))
             {
                 throw new DirectoryNotFoundException(directoryPath.NormalisedPath);
             }

--- a/src/Baseline.Filesystem.Adapters.S3/S3Adapter.File.cs
+++ b/src/Baseline.Filesystem.Adapters.S3/S3Adapter.File.cs
@@ -47,10 +47,7 @@ namespace Baseline.Filesystem.Adapters.S3
             CancellationToken cancellationToken
         )
         {
-            return await FileExistsInternalAsync(
-                fileExistsRequest.FilePath, 
-                cancellationToken
-            ).ConfigureAwait(false);
+            return await FileExistsInternalAsync(fileExistsRequest.FilePath, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
@@ -59,11 +56,7 @@ namespace Baseline.Filesystem.Adapters.S3
             CancellationToken cancellationToken
         )
         {
-            var fileExists = await FileExistsInternalAsync(
-                getFileRequest.FilePath, 
-                cancellationToken
-            ).ConfigureAwait(false);
-            
+            var fileExists = await FileExistsInternalAsync(getFileRequest.FilePath, cancellationToken).ConfigureAwait(false);
             return fileExists ? new FileRepresentation {Path = getFileRequest.FilePath} : null;
         }
 
@@ -111,9 +104,7 @@ namespace Baseline.Filesystem.Adapters.S3
         )
         {
             await EnsureFileDoesNotExistAsync(touchFileRequest.FilePath, cancellationToken).ConfigureAwait(false);
-            
             await TouchFileInternalAsync(touchFileRequest.FilePath, cancellationToken).ConfigureAwait(false);
-
             return new FileRepresentation { Path = touchFileRequest.FilePath };
         }
 

--- a/src/Baseline.Filesystem.Adapters.S3/S3Adapter.cs
+++ b/src/Baseline.Filesystem.Adapters.S3/S3Adapter.cs
@@ -1,5 +1,4 @@
 ﻿using Amazon.S3;
-using Baseline.Filesystem.Internal.Contracts;
 
 namespace Baseline.Filesystem.Adapters.S3
 {
@@ -10,7 +9,6 @@ namespace Baseline.Filesystem.Adapters.S3
     public partial class S3Adapter : IAdapter
     {
         private readonly S3AdapterConfiguration _adapterConfiguration;
-        private readonly PathRepresentation _basePath;
         private readonly IAmazonS3 _s3Client;
 
         /// <summary>
@@ -22,26 +20,6 @@ namespace Baseline.Filesystem.Adapters.S3
         {
             _adapterConfiguration = adapterConfiguration;
             _s3Client = _adapterConfiguration.S3Client;
-            
-            if (!string.IsNullOrWhiteSpace(adapterConfiguration.RootPath))
-            {
-                _basePath = new PathRepresentationBuilder(adapterConfiguration.RootPath).Build();   
-            }
-        }
-
-        /// <summary>
-        /// Combines the root path (if specified) with the path specified as part of the request.
-        /// </summary>
-        /// <param name="requestedPath">The path specified as part of the request.</param>
-        /// <returns>The combined paths, if applicable, or the request path if not.</returns>
-        private PathRepresentation CombineRootAndRequestedPath(PathRepresentation requestedPath)
-        {
-            if (_basePath == null)
-            {
-                return requestedPath;
-            }
-            
-            return new PathCombinationBuilder(_basePath, requestedPath).Build();
         }
     }
 }

--- a/src/Baseline.Filesystem.Adapters.S3/S3AdapterConfiguration.cs
+++ b/src/Baseline.Filesystem.Adapters.S3/S3AdapterConfiguration.cs
@@ -1,12 +1,11 @@
 ﻿using Amazon.S3;
-using Baseline.Filesystem.Configuration;
 
 namespace Baseline.Filesystem.Adapters.S3
 {
     /// <summary>
     /// Configuration options for the S3 adapter.
     /// </summary>
-    public class S3AdapterConfiguration : BaseAdapterConfiguration
+    public class S3AdapterConfiguration
     {
         /// <summary>
         /// Gets or sets the S3 client to use in the adapter.

--- a/src/Baseline.Filesystem/AdapterManager.cs
+++ b/src/Baseline.Filesystem/AdapterManager.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using Baseline.Filesystem.Internal.Contracts;
 
 namespace Baseline.Filesystem
 {
@@ -8,11 +7,11 @@ namespace Baseline.Filesystem
     /// </summary>
     public class AdapterManager : IAdapterManager
     {
-        private readonly ConcurrentDictionary<string, IAdapter> _adapters =
-            new ConcurrentDictionary<string, IAdapter>();
+        private readonly ConcurrentDictionary<string, AdapterRegistration> _adapters =
+            new ConcurrentDictionary<string, AdapterRegistration>();
             
         /// <inheritdoc />
-        public IAdapter Get(string name)
+        public AdapterRegistration Get(string name)
         {
             var normalisedName = NormaliseAdapterName(name);
 
@@ -23,14 +22,14 @@ namespace Baseline.Filesystem
         }
 
         /// <inheritdoc />
-        public void Register(IAdapter adapter, string name = "default")
+        public void Register(AdapterRegistration registration)
         {
-            var normalisedName = NormaliseAdapterName(name);
+            var normalisedName = NormaliseAdapterName(registration.Name);
 
             if (AdapterAlreadyRegistered(normalisedName))
                 throw new AdapterAlreadyRegisteredException(normalisedName);
 
-            _adapters[normalisedName] = adapter;
+            _adapters[normalisedName] = registration;
         }
 
         /// <summary>

--- a/src/Baseline.Filesystem/BaseAdapterWrapperManager.cs
+++ b/src/Baseline.Filesystem/BaseAdapterWrapperManager.cs
@@ -1,5 +1,3 @@
-using Baseline.Filesystem.Internal.Contracts;
-
 namespace Baseline.Filesystem
 {
     /// <summary>
@@ -21,13 +19,23 @@ namespace Baseline.Filesystem
         }
 
         /// <summary>
-        /// Gets an adapter from the adapter manage by its registered name.
+        /// Gets the root path for an adapter if it has one, or returns null.
         /// </summary>
-        /// <param name="adapterName">The name to retrieve the adapter by.</param>
-        /// <returns>The adapter retrieved from the adapter manager.</returns>
+        /// <param name="adapterName">The name of the adapter to retrieve the root path from.</param>
+        /// <returns>The root path for the adapter if it has one.</returns>
+        protected PathRepresentation GetAdapterRootPath(string adapterName)
+        {
+            return _adapterManager.Get(adapterName).RootPath;
+        }
+
+        /// <summary>
+        /// Gets an adapter by its registered name.
+        /// </summary>
+        /// <param name="adapterName">The name the adapter is registered under.</param>
+        /// <returns>The adapter, if it is registered, or an exception if it is not.</returns>
         protected IAdapter GetAdapter(string adapterName)
         {
-            return _adapterManager.Get(adapterName);
+            return _adapterManager.Get(adapterName).Adapter;
         }
     }
 }

--- a/src/Baseline.Filesystem/Baseline.Filesystem.csproj
+++ b/src/Baseline.Filesystem/Baseline.Filesystem.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Folder Include="Internal\Contracts" />
+  </ItemGroup>
+
 </Project>

--- a/src/Baseline.Filesystem/Baseline.Filesystem.csproj
+++ b/src/Baseline.Filesystem/Baseline.Filesystem.csproj
@@ -4,8 +4,4 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Folder Include="Internal\Contracts" />
-  </ItemGroup>
-
 </Project>

--- a/src/Baseline.Filesystem/Baseline.Filesystem.csproj.DotSettings
+++ b/src/Baseline.Filesystem/Baseline.Filesystem.csproj.DotSettings
@@ -1,0 +1,10 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=builders/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=configuration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=contracts/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=exceptions/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=extensions/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=representations/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=requests/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=requests_005Cdirectory/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=requests_005Cfile/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Baseline.Filesystem/Configuration/AdapterRegistration.cs
+++ b/src/Baseline.Filesystem/Configuration/AdapterRegistration.cs
@@ -1,10 +1,20 @@
-namespace Baseline.Filesystem.Configuration
+namespace Baseline.Filesystem
 {
     /// <summary>
-    /// Base adapter configuration which defines common functionality across all adapter configuration objects.
+    /// Configuration class containing all of the properties and information required to register an adapter.
     /// </summary>
-    public class BaseAdapterConfiguration
+    public class AdapterRegistration
     {
+        /// <summary>
+        /// Gets or sets the adapter instance to be registered.
+        /// </summary>
+        public IAdapter Adapter { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the name of the adapter.
+        /// </summary>
+        public string Name { get; set; } = "default";
+        
         /// <summary>
         /// Gets or sets an optional root path which is always combined with a path specified in any call to any methods
         /// within an adapter. This is a great feature to use when you want to keep normalised URLs in your application
@@ -21,6 +31,6 @@ namespace Baseline.Filesystem.Configuration
         ///     - If, in the future, I decide I want to use a physical file system, I can use the file system adapter,
         ///       configure its root path accordingly, and not have to change anything within my application. 
         /// </summary>
-        public string RootPath { get; set; }
+        public PathRepresentation RootPath { get; set; }
     }
 }

--- a/src/Baseline.Filesystem/Contracts/IAdapter.cs
+++ b/src/Baseline.Filesystem/Contracts/IAdapter.cs
@@ -1,7 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Baseline.Filesystem.Internal.Contracts
+namespace Baseline.Filesystem
 {
     /// <summary>
     /// Provides an interface for all Baseline.Filesystem adapters. Implementations are not aware that there may be more than one

--- a/src/Baseline.Filesystem/Contracts/IAdapterManager.cs
+++ b/src/Baseline.Filesystem/Contracts/IAdapterManager.cs
@@ -1,5 +1,3 @@
-using Baseline.Filesystem.Internal.Contracts;
-
 namespace Baseline.Filesystem
 {
     /// <summary>
@@ -11,20 +9,19 @@ namespace Baseline.Filesystem
     public interface IAdapterManager
     {
         /// <summary>
-        /// Gets an adapter by its registered name.
+        /// Gets an adapter registration by its registered name.
         /// </summary>
         /// <param name="name">The name of the adapter.</param>
-        /// <returns>The adapter instance if it is found.</returns>
+        /// <returns>The adapter registration if it is found.</returns>
         /// <exception cref="AdapterNotFoundException" />
-        IAdapter Get(string name);
+        AdapterRegistration Get(string name);
 
         /// <summary>
         /// Registers an adapter by a specified name. Names are normalised (lowercased). Duplicates will result in an
         /// exception being thrown.
         /// </summary>
-        /// <param name="adapter">The adapter to register.</param>
-        /// <param name="name">The name of the adapter.</param>
+        /// <param name="registration">The registration class containing the adapter, its name, and its root path.</param>
         /// <exception cref="AdapterAlreadyRegisteredException" />
-        void Register(IAdapter adapter, string name = "default");
+        void Register(AdapterRegistration registration);
     }
 }

--- a/src/Baseline.Filesystem/Contracts/IFileManager.cs
+++ b/src/Baseline.Filesystem/Contracts/IFileManager.cs
@@ -43,7 +43,6 @@ namespace Baseline.Filesystem
         /// <param name="cancellationToken">
         /// The cancellation token used to cancel asynchronous requests if required.
         /// </param>
-        /// <returns>An awaitable task.</returns>
         /// <exception cref="ArgumentNullException" />
         /// <exception cref="AdapterNotFoundException" />
         /// <exception cref="AdapterProviderOperationException" />
@@ -191,7 +190,6 @@ namespace Baseline.Filesystem
         /// <param name="cancellationToken">
         /// The cancellation token used to cancel asynchronous requests if required.
         /// </param>
-        /// <returns>An awaitable task.</returns>
         /// <exception cref="ArgumentNullException" />
         /// <exception cref="AdapterNotFoundException" />
         /// <exception cref="AdapterProviderOperationException" />

--- a/src/Baseline.Filesystem/DirectoryManager.cs
+++ b/src/Baseline.Filesystem/DirectoryManager.cs
@@ -29,7 +29,7 @@ namespace Baseline.Filesystem
 
             return GetAdapter(adapter)
                 .CopyDirectoryAsync(
-                    copyDirectoryRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)), 
+                    copyDirectoryRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)), 
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
@@ -46,7 +46,7 @@ namespace Baseline.Filesystem
 
             return GetAdapter(adapter)
                 .CreateDirectoryAsync(
-                    createDirectoryRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)),
+                    createDirectoryRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
@@ -63,7 +63,7 @@ namespace Baseline.Filesystem
             
             return GetAdapter(adapter)
                 .DeleteDirectoryAsync(
-                    deleteDirectoryRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)), 
+                    deleteDirectoryRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)), 
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter);
@@ -80,7 +80,7 @@ namespace Baseline.Filesystem
             
             return GetAdapter(adapter)
                 .MoveDirectoryAsync(
-                    moveDirectoryRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)),
+                    moveDirectoryRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)

--- a/src/Baseline.Filesystem/DirectoryManager.cs
+++ b/src/Baseline.Filesystem/DirectoryManager.cs
@@ -28,7 +28,10 @@ namespace Baseline.Filesystem
             BaseSourceAndDestinationDirectoryRequestValidator.ValidateAndThrowIfUnsuccessful(copyDirectoryRequest);
 
             return GetAdapter(adapter)
-                .CopyDirectoryAsync(copyDirectoryRequest, cancellationToken)
+                .CopyDirectoryAsync(
+                    copyDirectoryRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)), 
+                    cancellationToken
+                )
                 .WrapExternalExceptionsAsync(adapter)
                 .AsAdapterAwareRepresentationAsync(adapter);
         }
@@ -42,7 +45,10 @@ namespace Baseline.Filesystem
             BaseSingleDirectoryRequestValidator.ValidateAndThrowIfUnsuccessful(createDirectoryRequest);
 
             return GetAdapter(adapter)
-                .CreateDirectoryAsync(createDirectoryRequest, cancellationToken)
+                .CreateDirectoryAsync(
+                    createDirectoryRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)),
+                    cancellationToken
+                )
                 .WrapExternalExceptionsAsync(adapter)
                 .AsAdapterAwareRepresentationAsync(adapter);
         }
@@ -56,7 +62,10 @@ namespace Baseline.Filesystem
             BaseSingleDirectoryRequestValidator.ValidateAndThrowIfUnsuccessful(deleteDirectoryRequest);
             
             return GetAdapter(adapter)
-                .DeleteDirectoryAsync(deleteDirectoryRequest, cancellationToken)
+                .DeleteDirectoryAsync(
+                    deleteDirectoryRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)), 
+                    cancellationToken
+                )
                 .WrapExternalExceptionsAsync(adapter);
         }
 
@@ -68,9 +77,12 @@ namespace Baseline.Filesystem
         )
         {
             BaseSourceAndDestinationDirectoryRequestValidator.ValidateAndThrowIfUnsuccessful(moveDirectoryRequest);
-
+            
             return GetAdapter(adapter)
-                .MoveDirectoryAsync(moveDirectoryRequest, cancellationToken)
+                .MoveDirectoryAsync(
+                    moveDirectoryRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)),
+                    cancellationToken
+                )
                 .WrapExternalExceptionsAsync(adapter)
                 .AsAdapterAwareRepresentationAsync(adapter);
         }

--- a/src/Baseline.Filesystem/Exceptions/DirectoryAlreadyExistsException.cs
+++ b/src/Baseline.Filesystem/Exceptions/DirectoryAlreadyExistsException.cs
@@ -8,11 +8,9 @@ namespace Baseline.Filesystem
         /// <summary>
         /// Initialises a new instance of the <see cref="DirectoryAlreadyExistsException"/> class.
         /// </summary>
-        /// <param name="pathWithRoot">The requested path combined with the root path of the adapter if set.</param>
-        /// <param name="path">The requested path without the root path of the adapter.</param>
-        public DirectoryAlreadyExistsException(string pathWithRoot, string path)
-            : base($"The directory (path with root: {pathWithRoot}, path without root: {path}) already exists " +
-                   $"and cannot be created, copied to or moved to.")
+        /// <param name="path">The requested path that already exists.</param>
+        public DirectoryAlreadyExistsException(string path)
+            : base($"The directory ({path}) already exists and cannot be created, copied to or moved to.")
         {
         }
     }

--- a/src/Baseline.Filesystem/Exceptions/DirectoryNotFoundException.cs
+++ b/src/Baseline.Filesystem/Exceptions/DirectoryNotFoundException.cs
@@ -8,10 +8,8 @@ namespace Baseline.Filesystem
         /// <summary>
         /// Initialises a new instance of the <see cref="DirectoryNotFoundException"/> class.
         /// </summary>
-        /// <param name="pathWithRoot">The requested path combined with the root path of the adapter if set.</param>
-        /// <param name="path">The requested path without the root path of the adapter.</param>
-        public DirectoryNotFoundException(string pathWithRoot, string path)
-            : base($"The directory (path with root: {pathWithRoot}, path without root: {path}) was not found.")
+        /// <param name="path">The requested path that does not exist.</param>
+        public DirectoryNotFoundException(string path) : base($"The directory ({path}) was not found.")
         {
         }
     }

--- a/src/Baseline.Filesystem/Exceptions/FileAlreadyExistsException.cs
+++ b/src/Baseline.Filesystem/Exceptions/FileAlreadyExistsException.cs
@@ -8,11 +8,9 @@
         /// <summary>
         /// Initialises a new instance of the <see cref="FileAlreadyExistsException" /> class.
         /// </summary>
-        /// <param name="pathWithRoot">The path that already exists with the root path (if applicable).</param>
-        /// <param name="path">The path to the file excluding the root path.</param>
-        public FileAlreadyExistsException(string pathWithRoot, string path)
-            : base($"The file (path with root: {pathWithRoot}, path without root: {path}) already exists and cannot " +
-                   $"be written to.")
+        /// <param name="path">The path to the file that already exists.</param>
+        public FileAlreadyExistsException(string path)
+            : base($"The file ({path}) already exists and cannot be written to.")
         {}
     }
 }

--- a/src/Baseline.Filesystem/Exceptions/FileNotFoundException.cs
+++ b/src/Baseline.Filesystem/Exceptions/FileNotFoundException.cs
@@ -8,13 +8,8 @@
         /// <summary>
         /// Initialises a new instance of the <see cref="FileNotFoundException" /> class.
         /// </summary>
-        /// <param name="pathWithRoot">
-        /// The path with the root for the adapter (if one is specified). If one isn't specified this will be the same
-        /// as <see cref="path" />.
-        /// </param>
         /// <param name="path">The path to the file that was not found.</param>
-        public FileNotFoundException(string pathWithRoot, string path)
-            : base($"The file (path with root: {pathWithRoot}, path without root: {path}) was not found.")
+        public FileNotFoundException(string path) : base($"The file ({path}) was not found.")
         {
         }
     }

--- a/src/Baseline.Filesystem/FileManager.cs
+++ b/src/Baseline.Filesystem/FileManager.cs
@@ -28,7 +28,10 @@ namespace Baseline.Filesystem
             BaseSourceAndDestinationFileRequestValidator.ValidateAndThrowIfUnsuccessful(copyFileRequest);
             
             return GetAdapter(adapter)
-                .CopyFileAsync(copyFileRequest, cancellationToken)
+                .CopyFileAsync(
+                    copyFileRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)),
+                    cancellationToken
+                )
                 .WrapExternalExceptionsAsync(adapter)
                 .AsAdapterAwareRepresentationAsync(adapter);
         }
@@ -43,7 +46,10 @@ namespace Baseline.Filesystem
             BaseSingleFileRequestValidator.ValidateAndThrowIfUnsuccessful(deleteFileRequest);
 
             return GetAdapter(adapter)
-                .DeleteFileAsync(deleteFileRequest, cancellationToken)
+                .DeleteFileAsync(
+                    deleteFileRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)),
+                    cancellationToken
+                )
                 .WrapExternalExceptionsAsync(adapter);
         }
 
@@ -57,7 +63,10 @@ namespace Baseline.Filesystem
             BaseSingleFileRequestValidator.ValidateAndThrowIfUnsuccessful(fileExistsRequest);
 
             return GetAdapter(adapter)
-                .FileExistsAsync(fileExistsRequest, cancellationToken)
+                .FileExistsAsync(
+                    fileExistsRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)), 
+                    cancellationToken
+                )
                 .WrapExternalExceptionsAsync(adapter);
         }
 
@@ -71,7 +80,10 @@ namespace Baseline.Filesystem
             BaseSingleFileRequestValidator.ValidateAndThrowIfUnsuccessful(getFileRequest);
     
             return GetAdapter(adapter)
-                .GetFileAsync(getFileRequest, cancellationToken)
+                .GetFileAsync(
+                    getFileRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)),
+                    cancellationToken
+                )
                 .WrapExternalExceptionsAsync(adapter)
                 .AsAdapterAwareRepresentationAsync(adapter);
         }
@@ -86,7 +98,10 @@ namespace Baseline.Filesystem
             BaseSourceAndDestinationFileRequestValidator.ValidateAndThrowIfUnsuccessful(moveFileRequest);
 
             return GetAdapter(adapter)
-                .MoveFileAsync(moveFileRequest, cancellationToken)
+                .MoveFileAsync(
+                    moveFileRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)),
+                    cancellationToken
+                )
                 .WrapExternalExceptionsAsync(adapter)
                 .AsAdapterAwareRepresentationAsync(adapter);
         }
@@ -101,7 +116,10 @@ namespace Baseline.Filesystem
             BaseSingleFileRequestValidator.ValidateAndThrowIfUnsuccessful(readFileAsStringRequest);
 
             return GetAdapter(adapter)
-                .ReadFileAsStringAsync(readFileAsStringRequest, cancellationToken)
+                .ReadFileAsStringAsync(
+                    readFileAsStringRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)),
+                    cancellationToken
+                )
                 .WrapExternalExceptionsAsync(adapter);
         }
 
@@ -115,7 +133,10 @@ namespace Baseline.Filesystem
             BaseSingleFileRequestValidator.ValidateAndThrowIfUnsuccessful(touchFileRequest);
             
             return GetAdapter(adapter)
-                .TouchFileAsync(touchFileRequest, cancellationToken)
+                .TouchFileAsync(
+                    touchFileRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)),
+                    cancellationToken
+                )
                 .WrapExternalExceptionsAsync(adapter)
                 .AsAdapterAwareRepresentationAsync(adapter);
         }
@@ -130,7 +151,10 @@ namespace Baseline.Filesystem
             WriteTextToFileRequestValidator.ValidateAndThrowIfUnsuccessful(writeTextToFileRequest);
 
             return GetAdapter(adapter)
-                .WriteTextToFileAsync(writeTextToFileRequest, cancellationToken)
+                .WriteTextToFileAsync(
+                    writeTextToFileRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)),
+                    cancellationToken
+                )
                 .WrapExternalExceptionsAsync(adapter);
         }
     }

--- a/src/Baseline.Filesystem/FileManager.cs
+++ b/src/Baseline.Filesystem/FileManager.cs
@@ -29,7 +29,7 @@ namespace Baseline.Filesystem
             
             return GetAdapter(adapter)
                 .CopyFileAsync(
-                    copyFileRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)),
+                    copyFileRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
@@ -47,7 +47,7 @@ namespace Baseline.Filesystem
 
             return GetAdapter(adapter)
                 .DeleteFileAsync(
-                    deleteFileRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)),
+                    deleteFileRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter);
@@ -64,7 +64,7 @@ namespace Baseline.Filesystem
 
             return GetAdapter(adapter)
                 .FileExistsAsync(
-                    fileExistsRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)), 
+                    fileExistsRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)), 
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter);
@@ -81,7 +81,7 @@ namespace Baseline.Filesystem
     
             return GetAdapter(adapter)
                 .GetFileAsync(
-                    getFileRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)),
+                    getFileRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
@@ -99,7 +99,7 @@ namespace Baseline.Filesystem
 
             return GetAdapter(adapter)
                 .MoveFileAsync(
-                    moveFileRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)),
+                    moveFileRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
@@ -117,7 +117,7 @@ namespace Baseline.Filesystem
 
             return GetAdapter(adapter)
                 .ReadFileAsStringAsync(
-                    readFileAsStringRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)),
+                    readFileAsStringRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter);
@@ -134,7 +134,7 @@ namespace Baseline.Filesystem
             
             return GetAdapter(adapter)
                 .TouchFileAsync(
-                    touchFileRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)),
+                    touchFileRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter)
@@ -152,7 +152,7 @@ namespace Baseline.Filesystem
 
             return GetAdapter(adapter)
                 .WriteTextToFileAsync(
-                    writeTextToFileRequest.CombinePathsWithRootPath(GetAdapterRootPath(adapter)),
+                    writeTextToFileRequest.CloneAndCombinePathsWithRootPath(GetAdapterRootPath(adapter)),
                     cancellationToken
                 )
                 .WrapExternalExceptionsAsync(adapter);

--- a/src/Baseline.Filesystem/Internal/Validators/Directories/BaseSingleDirectoryRequestValidator.cs
+++ b/src/Baseline.Filesystem/Internal/Validators/Directories/BaseSingleDirectoryRequestValidator.cs
@@ -3,7 +3,7 @@ using System;
 namespace Baseline.Filesystem.Internal.Validators.Directories
 {
     /// <summary>
-    /// Validation methods for the <see cref="BaseSingleDirectoryRequest"/> class.
+    /// Validation methods for the <see cref="BaseSingleDirectoryRequest{T}"/> class.
     /// </summary>
     public static class BaseSingleDirectoryRequestValidator
     {
@@ -11,7 +11,8 @@ namespace Baseline.Filesystem.Internal.Validators.Directories
         /// Validates the request and throws any exceptions if that validation is unsuccessful.
         /// </summary>
         /// <param name="request">The request to validate.</param>
-        public static void ValidateAndThrowIfUnsuccessful(BaseSingleDirectoryRequest request)
+        public static void ValidateAndThrowIfUnsuccessful<T>(BaseSingleDirectoryRequest<T> request)
+            where T : BaseSingleDirectoryRequest<T>, new()
         {
             if (request == null)
             {

--- a/src/Baseline.Filesystem/Internal/Validators/Directories/BaseSourceAndDestinationDirectoryRequestValidator.cs
+++ b/src/Baseline.Filesystem/Internal/Validators/Directories/BaseSourceAndDestinationDirectoryRequestValidator.cs
@@ -3,7 +3,7 @@ using System;
 namespace Baseline.Filesystem.Internal.Validators.Directories
 {
     /// <summary>
-    /// Validation methods for the <see cref="BaseSourceAndDestinationDirectoryRequest"/> class.
+    /// Validation methods for the <see cref="BaseSourceAndDestinationDirectoryRequest{T}"/> class.
     /// </summary>
     public static class BaseSourceAndDestinationDirectoryRequestValidator
     {
@@ -11,7 +11,9 @@ namespace Baseline.Filesystem.Internal.Validators.Directories
         /// Validates the request and throws exceptions for any failures.
         /// </summary>
         /// <param name="directoryRequest">The directory request to validate.</param>
-        public static void ValidateAndThrowIfUnsuccessful(BaseSourceAndDestinationDirectoryRequest directoryRequest)
+        public static void ValidateAndThrowIfUnsuccessful<T>(
+            BaseSourceAndDestinationDirectoryRequest<T> directoryRequest
+        ) where T : BaseSourceAndDestinationDirectoryRequest<T>, new()
         {
             if (directoryRequest == null)
             {

--- a/src/Baseline.Filesystem/Internal/Validators/Files/BaseSingleFileRequestValidator.cs
+++ b/src/Baseline.Filesystem/Internal/Validators/Files/BaseSingleFileRequestValidator.cs
@@ -3,7 +3,7 @@ using System;
 namespace Baseline.Filesystem.Internal.Validators.Files
 {
     /// <summary>
-    /// Validation methods for the <see cref="BaseSingleFileRequest" /> class.
+    /// Validation methods for the <see cref="BaseSingleFileRequest{T}" /> class.
     /// </summary>
     internal static class BaseSingleFileRequestValidator
     {
@@ -14,7 +14,8 @@ namespace Baseline.Filesystem.Internal.Validators.Files
         /// <param name="request">The base file request.</param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="PathIsADirectoryException"></exception>
-        public static void ValidateAndThrowIfUnsuccessful(BaseSingleFileRequest request)
+        public static void ValidateAndThrowIfUnsuccessful<T>(BaseSingleFileRequest<T> request) 
+            where T : BaseSingleFileRequest<T>, new()
         {
             if (request == null)
             {

--- a/src/Baseline.Filesystem/Internal/Validators/Files/BaseSourceAndDestinationFileRequestValidator.cs
+++ b/src/Baseline.Filesystem/Internal/Validators/Files/BaseSourceAndDestinationFileRequestValidator.cs
@@ -3,7 +3,7 @@ using System;
 namespace Baseline.Filesystem.Internal.Validators.Files
 {
     /// <summary>
-    /// Validation methods for the <see cref="BaseSourceAndDestinationFileRequest" /> class.
+    /// Validation methods for the <see cref="BaseSourceAndDestinationFileRequest{T}" /> class.
     /// </summary>
     internal static class BaseSourceAndDestinationFileRequestValidator
     {
@@ -12,7 +12,8 @@ namespace Baseline.Filesystem.Internal.Validators.Files
         /// </summary>
         /// <param name="fileRequest">The request to validate.</param>
         /// <exception cref="ArgumentNullException" />
-        public static void ValidateAndThrowIfUnsuccessful(BaseSourceAndDestinationFileRequest fileRequest)
+        public static void ValidateAndThrowIfUnsuccessful<T>(BaseSourceAndDestinationFileRequest<T> fileRequest) 
+            where T : BaseSourceAndDestinationFileRequest<T>, new()
         {
             if (fileRequest == null)
             {

--- a/src/Baseline.Filesystem/Representations/PathRepresentation.cs
+++ b/src/Baseline.Filesystem/Representations/PathRepresentation.cs
@@ -26,5 +26,16 @@ namespace Baseline.Filesystem
         /// Gets the original path that was specified by the consuming application.
         /// </summary>
         public string OriginalPath { get; internal set; }
+
+        /// <summary>
+        /// Combines the current path representation with a base path representation, wherein the base path
+        /// representation is set first, and the current path after.
+        /// </summary>
+        /// <param name="@base">The base path to combine with the current path.</param>
+        /// <returns>The newly combined path.</returns>
+        internal PathRepresentation CombineWithBase(PathRepresentation @base)
+        {
+            return new PathCombinationBuilder(@base, this).Build();
+        }
     }
 }

--- a/src/Baseline.Filesystem/Requests/BaseRequest.cs
+++ b/src/Baseline.Filesystem/Requests/BaseRequest.cs
@@ -10,13 +10,13 @@ namespace Baseline.Filesystem
         /// paths are modified (no values), so there is no need to clone any properties.
         /// </summary>
         /// <returns></returns>
-        internal abstract T CloneForPathUpdates();
+        internal abstract T ShallowClone();
 
         /// <summary>
         /// Clones the current instance and then combines the current instance's paths with a root path.
         /// </summary>
         /// <param name="rootPath">The root path to combine the current paths with.</param>
         /// <returns>A clone of the current instance with its paths combined with a root path.</returns>
-        internal abstract T CombinePathsWithRootPath(PathRepresentation rootPath);
+        internal abstract T CloneAndCombinePathsWithRootPath(PathRepresentation rootPath);
     }
 }

--- a/src/Baseline.Filesystem/Requests/BaseRequest.cs
+++ b/src/Baseline.Filesystem/Requests/BaseRequest.cs
@@ -1,0 +1,22 @@
+namespace Baseline.Filesystem
+{
+    /// <summary>
+    /// Base request containing functionality that all Baseline.Filesystem requests must implement.
+    /// </summary>
+    public abstract class BaseRequest<T> where T : BaseRequest<T>, new()
+    {
+        /// <summary>
+        /// Clones the current instance into a new instance ready for the paths to be updated. Only the references for
+        /// paths are modified (no values), so there is no need to clone any properties.
+        /// </summary>
+        /// <returns></returns>
+        internal abstract T CloneForPathUpdates();
+
+        /// <summary>
+        /// Clones the current instance and then combines the current instance's paths with a root path.
+        /// </summary>
+        /// <param name="rootPath">The root path to combine the current paths with.</param>
+        /// <returns>A clone of the current instance with its paths combined with a root path.</returns>
+        internal abstract T CombinePathsWithRootPath(PathRepresentation rootPath);
+    }
+}

--- a/src/Baseline.Filesystem/Requests/Directory/BaseSingleDirectoryRequest.cs
+++ b/src/Baseline.Filesystem/Requests/Directory/BaseSingleDirectoryRequest.cs
@@ -3,11 +3,44 @@ namespace Baseline.Filesystem
     /// <summary>
     /// Base class containing all properties for single directory based requests.
     /// </summary>
-    public class BaseSingleDirectoryRequest
+    public abstract class BaseSingleDirectoryRequest<T> : BaseRequest<T>
+        where T : BaseSingleDirectoryRequest<T>, new()
     {
         /// <summary>
         /// Gets or sets the directory path to use in the request.
         /// </summary>
         public PathRepresentation DirectoryPath { get; set; }
+
+        /// <summary>
+        /// Combines the paths belonging to this request with a root path, if the root path is not null.
+        /// </summary>
+        /// <param name="rootPath">The root path to combine the current paths with.</param>
+        /// <returns>
+        /// A cloned version of the current class, with the paths combined with the root path if applicable.
+        /// </returns>
+        internal override T CombinePathsWithRootPath(PathRepresentation rootPath)
+        {
+            if (rootPath == null)
+            {
+                return (T)this;
+            }
+
+            var cloned = CloneForPathUpdates();
+            cloned.DirectoryPath = cloned.DirectoryPath.CombineWithBase(rootPath);
+            return cloned;
+        }
+        
+        /// <summary>
+        /// Clones the current instance for path updates. Some properties do not need to be cloned (for example path
+        /// representations) as they're never modified.
+        /// </summary>
+        /// <returns>A clone of the current instance.</returns>
+        internal override T CloneForPathUpdates()
+        {
+            return new T
+            {
+                DirectoryPath = DirectoryPath
+            };
+        }
     }
 }

--- a/src/Baseline.Filesystem/Requests/Directory/BaseSingleDirectoryRequest.cs
+++ b/src/Baseline.Filesystem/Requests/Directory/BaseSingleDirectoryRequest.cs
@@ -18,14 +18,14 @@ namespace Baseline.Filesystem
         /// <returns>
         /// A cloned version of the current class, with the paths combined with the root path if applicable.
         /// </returns>
-        internal override T CombinePathsWithRootPath(PathRepresentation rootPath)
+        internal override T CloneAndCombinePathsWithRootPath(PathRepresentation rootPath)
         {
             if (rootPath == null)
             {
                 return (T)this;
             }
 
-            var cloned = CloneForPathUpdates();
+            var cloned = ShallowClone();
             cloned.DirectoryPath = cloned.DirectoryPath.CombineWithBase(rootPath);
             return cloned;
         }
@@ -35,7 +35,7 @@ namespace Baseline.Filesystem
         /// representations) as they're never modified.
         /// </summary>
         /// <returns>A clone of the current instance.</returns>
-        internal override T CloneForPathUpdates()
+        internal override T ShallowClone()
         {
             return new T
             {

--- a/src/Baseline.Filesystem/Requests/Directory/BaseSourceAndDestinationDirectoryRequest.cs
+++ b/src/Baseline.Filesystem/Requests/Directory/BaseSourceAndDestinationDirectoryRequest.cs
@@ -3,7 +3,8 @@ namespace Baseline.Filesystem
     /// <summary>
     /// Base class containing all properties for a source and destination based directory request.
     /// </summary>
-    public class BaseSourceAndDestinationDirectoryRequest
+    public abstract class BaseSourceAndDestinationDirectoryRequest<T> : BaseRequest<T>
+        where T : BaseSourceAndDestinationDirectoryRequest<T>, new()
     {
         /// <summary>
         /// Gets or sets the source directory path.
@@ -14,5 +15,39 @@ namespace Baseline.Filesystem
         /// Gets or sets the destination directory path.
         /// </summary>
         public PathRepresentation DestinationDirectoryPath { get; set; }
+        
+        /// <summary>
+        /// Combines the paths belonging to this request with a root path, if the root path is not null.
+        /// </summary>
+        /// <param name="rootPath">The root path to combine the current paths with.</param>
+        /// <returns>
+        /// A cloned version of the current class, with the paths combined with the root path if applicable.
+        /// </returns>
+        internal override T CombinePathsWithRootPath(PathRepresentation rootPath)
+        {
+            if (rootPath == null)
+            {
+                return (T)this;
+            }
+
+            var cloned = CloneForPathUpdates();
+            cloned.SourceDirectoryPath = cloned.SourceDirectoryPath.CombineWithBase(rootPath);
+            cloned.DestinationDirectoryPath = cloned.DestinationDirectoryPath.CombineWithBase(rootPath);
+            return cloned;
+        }
+        
+        /// <summary>
+        /// Clones the current instance for path updates. Some properties do not need to be cloned (for example path
+        /// representations) as they're never modified.
+        /// </summary>
+        /// <returns>A clone of the current instance.</returns>
+        internal override T CloneForPathUpdates()
+        {
+            return new T
+            {
+                SourceDirectoryPath = SourceDirectoryPath,
+                DestinationDirectoryPath = DestinationDirectoryPath
+            };
+        }
     }
 }

--- a/src/Baseline.Filesystem/Requests/Directory/BaseSourceAndDestinationDirectoryRequest.cs
+++ b/src/Baseline.Filesystem/Requests/Directory/BaseSourceAndDestinationDirectoryRequest.cs
@@ -23,14 +23,14 @@ namespace Baseline.Filesystem
         /// <returns>
         /// A cloned version of the current class, with the paths combined with the root path if applicable.
         /// </returns>
-        internal override T CombinePathsWithRootPath(PathRepresentation rootPath)
+        internal override T CloneAndCombinePathsWithRootPath(PathRepresentation rootPath)
         {
             if (rootPath == null)
             {
                 return (T)this;
             }
 
-            var cloned = CloneForPathUpdates();
+            var cloned = ShallowClone();
             cloned.SourceDirectoryPath = cloned.SourceDirectoryPath.CombineWithBase(rootPath);
             cloned.DestinationDirectoryPath = cloned.DestinationDirectoryPath.CombineWithBase(rootPath);
             return cloned;
@@ -41,7 +41,7 @@ namespace Baseline.Filesystem
         /// representations) as they're never modified.
         /// </summary>
         /// <returns>A clone of the current instance.</returns>
-        internal override T CloneForPathUpdates()
+        internal override T ShallowClone()
         {
             return new T
             {

--- a/src/Baseline.Filesystem/Requests/Directory/CopyDirectoryRequest.cs
+++ b/src/Baseline.Filesystem/Requests/Directory/CopyDirectoryRequest.cs
@@ -3,7 +3,7 @@ namespace Baseline.Filesystem
     /// <summary>
     /// Request used to copy a directory from one location to another.
     /// </summary>
-    public class CopyDirectoryRequest : BaseSourceAndDestinationDirectoryRequest
+    public class CopyDirectoryRequest : BaseSourceAndDestinationDirectoryRequest<CopyDirectoryRequest>
     {
     }
 }

--- a/src/Baseline.Filesystem/Requests/Directory/CreateDirectoryRequest.cs
+++ b/src/Baseline.Filesystem/Requests/Directory/CreateDirectoryRequest.cs
@@ -3,7 +3,7 @@ namespace Baseline.Filesystem
     /// <summary>
     /// Request used to create a directory.
     /// </summary>
-    public class CreateDirectoryRequest : BaseSingleDirectoryRequest
+    public class CreateDirectoryRequest : BaseSingleDirectoryRequest<CreateDirectoryRequest>
     {
     }
 }

--- a/src/Baseline.Filesystem/Requests/Directory/DeleteDirectoryRequest.cs
+++ b/src/Baseline.Filesystem/Requests/Directory/DeleteDirectoryRequest.cs
@@ -3,7 +3,7 @@ namespace Baseline.Filesystem
     /// <summary>
     /// Request used to delete a directory.
     /// </summary>
-    public class DeleteDirectoryRequest : BaseSingleDirectoryRequest
+    public class DeleteDirectoryRequest : BaseSingleDirectoryRequest<DeleteDirectoryRequest>
     {
     }
 }

--- a/src/Baseline.Filesystem/Requests/Directory/MoveDirectoryRequest.cs
+++ b/src/Baseline.Filesystem/Requests/Directory/MoveDirectoryRequest.cs
@@ -3,7 +3,7 @@ namespace Baseline.Filesystem
     /// <summary>
     /// Request used to move a directory from one location to another.
     /// </summary>
-    public class MoveDirectoryRequest : BaseSourceAndDestinationDirectoryRequest
+    public class MoveDirectoryRequest : BaseSourceAndDestinationDirectoryRequest<MoveDirectoryRequest>
     {
     }
 }

--- a/src/Baseline.Filesystem/Requests/File/BaseSingleFileRequest.cs
+++ b/src/Baseline.Filesystem/Requests/File/BaseSingleFileRequest.cs
@@ -3,11 +3,44 @@ namespace Baseline.Filesystem
     /// <summary>
     /// Base class containing all properties for basic file requests that only operate against one file.
     /// </summary>
-    public abstract class BaseSingleFileRequest
+    public abstract class BaseSingleFileRequest<T> : BaseRequest<T>
+        where T : BaseSingleFileRequest<T>, new()
     {
         /// <summary>
         /// Gets or sets the file path to use to perform the action against.
         /// </summary>
         public PathRepresentation FilePath { get; set; }
+        
+        /// <summary>
+        /// Combines the paths belonging to this request with a root path, if the root path is not null.
+        /// </summary>
+        /// <param name="rootPath">The root path to combine the current paths with.</param>
+        /// <returns>
+        /// A cloned version of the current class, with the paths combined with the root path if applicable.
+        /// </returns>
+        internal override T CombinePathsWithRootPath(PathRepresentation rootPath)
+        {
+            if (rootPath == null)
+            {
+                return (T)this;
+            }
+
+            var cloned = CloneForPathUpdates();
+            cloned.FilePath = cloned.FilePath.CombineWithBase(rootPath);
+            return cloned;
+        }
+        
+        /// <summary>
+        /// Clones the current instance for path updates. Some properties do not need to be cloned (for example path
+        /// representations) as they're never modified.
+        /// </summary>
+        /// <returns>A clone of the current instance.</returns>
+        internal override T CloneForPathUpdates()
+        {
+            return new T
+            {
+                FilePath = FilePath
+            };
+        }
     }
 }

--- a/src/Baseline.Filesystem/Requests/File/BaseSingleFileRequest.cs
+++ b/src/Baseline.Filesystem/Requests/File/BaseSingleFileRequest.cs
@@ -18,24 +18,23 @@ namespace Baseline.Filesystem
         /// <returns>
         /// A cloned version of the current class, with the paths combined with the root path if applicable.
         /// </returns>
-        internal override T CombinePathsWithRootPath(PathRepresentation rootPath)
+        internal override T CloneAndCombinePathsWithRootPath(PathRepresentation rootPath)
         {
             if (rootPath == null)
             {
                 return (T)this;
             }
 
-            var cloned = CloneForPathUpdates();
+            var cloned = ShallowClone();
             cloned.FilePath = cloned.FilePath.CombineWithBase(rootPath);
             return cloned;
         }
         
         /// <summary>
-        /// Clones the current instance for path updates. Some properties do not need to be cloned (for example path
-        /// representations) as they're never modified.
+        /// Clones the current instance for path updates. This only needs to be a shallow (i.e. top level) clone.
         /// </summary>
         /// <returns>A clone of the current instance.</returns>
-        internal override T CloneForPathUpdates()
+        internal override T ShallowClone()
         {
             return new T
             {

--- a/src/Baseline.Filesystem/Requests/File/BaseSourceAndDestinationFileRequest.cs
+++ b/src/Baseline.Filesystem/Requests/File/BaseSourceAndDestinationFileRequest.cs
@@ -24,14 +24,14 @@ namespace Baseline.Filesystem
         /// <returns>
         /// A cloned version of the current class, with the paths combined with the root path if applicable.
         /// </returns>
-        internal override T CombinePathsWithRootPath(PathRepresentation rootPath)
+        internal override T CloneAndCombinePathsWithRootPath(PathRepresentation rootPath)
         {
             if (rootPath == null)
             {
                 return (T)this;
             }
 
-            var cloned = CloneForPathUpdates();
+            var cloned = ShallowClone();
             cloned.SourceFilePath = cloned.SourceFilePath.CombineWithBase(rootPath);
             cloned.DestinationFilePath = cloned.DestinationFilePath.CombineWithBase(rootPath);
             return cloned;
@@ -42,7 +42,7 @@ namespace Baseline.Filesystem
         /// representations) as they're never modified.
         /// </summary>
         /// <returns>A clone of the current instance.</returns>
-        internal override T CloneForPathUpdates()
+        internal override T ShallowClone()
         {
             return new T
             {

--- a/src/Baseline.Filesystem/Requests/File/BaseSourceAndDestinationFileRequest.cs
+++ b/src/Baseline.Filesystem/Requests/File/BaseSourceAndDestinationFileRequest.cs
@@ -4,7 +4,8 @@ namespace Baseline.Filesystem
     /// Base class for requests that operate against a source and a destination (for example the copy and move
     /// operations).
     /// </summary>
-    public abstract class BaseSourceAndDestinationFileRequest
+    public abstract class BaseSourceAndDestinationFileRequest<T> : BaseRequest<T>
+        where T : BaseSourceAndDestinationFileRequest<T>, new()
     {
         /// <summary>
         /// Gets or sets the source path.
@@ -15,5 +16,39 @@ namespace Baseline.Filesystem
         /// Gets or sets the destination path.
         /// </summary>
         public PathRepresentation DestinationFilePath { get; set; }
+
+        /// <summary>
+        /// Combines the paths belonging to this request with a root path, if the root path is not null.
+        /// </summary>
+        /// <param name="rootPath">The root path to combine the current paths with.</param>
+        /// <returns>
+        /// A cloned version of the current class, with the paths combined with the root path if applicable.
+        /// </returns>
+        internal override T CombinePathsWithRootPath(PathRepresentation rootPath)
+        {
+            if (rootPath == null)
+            {
+                return (T)this;
+            }
+
+            var cloned = CloneForPathUpdates();
+            cloned.SourceFilePath = cloned.SourceFilePath.CombineWithBase(rootPath);
+            cloned.DestinationFilePath = cloned.DestinationFilePath.CombineWithBase(rootPath);
+            return cloned;
+        }
+        
+        /// <summary>
+        /// Clones the current instance for path updates. Some properties do not need to be cloned (for example path
+        /// representations) as they're never modified.
+        /// </summary>
+        /// <returns>A clone of the current instance.</returns>
+        internal override T CloneForPathUpdates()
+        {
+            return new T
+            {
+                SourceFilePath = SourceFilePath,
+                DestinationFilePath = DestinationFilePath
+            };
+        }
     }
 }

--- a/src/Baseline.Filesystem/Requests/File/CopyFileRequest.cs
+++ b/src/Baseline.Filesystem/Requests/File/CopyFileRequest.cs
@@ -3,7 +3,7 @@ namespace Baseline.Filesystem
     /// <summary>
     /// Request used to copy a file from one location to another.
     /// </summary>
-    public class CopyFileRequest : BaseSourceAndDestinationFileRequest
+    public class CopyFileRequest : BaseSourceAndDestinationFileRequest<CopyFileRequest>
     {
     }
 }

--- a/src/Baseline.Filesystem/Requests/File/DeleteFileRequest.cs
+++ b/src/Baseline.Filesystem/Requests/File/DeleteFileRequest.cs
@@ -3,7 +3,7 @@ namespace Baseline.Filesystem
     /// <summary>
     /// Request used to delete a file from an adapter's store.
     /// </summary>
-    public class DeleteFileRequest : BaseSingleFileRequest
+    public class DeleteFileRequest : BaseSingleFileRequest<DeleteFileRequest>
     {
     }
 }

--- a/src/Baseline.Filesystem/Requests/File/FileExistsRequest.cs
+++ b/src/Baseline.Filesystem/Requests/File/FileExistsRequest.cs
@@ -3,7 +3,7 @@ namespace Baseline.Filesystem
     /// <summary>
     /// Request used to check whether or not a file exists.
     /// </summary>
-    public class FileExistsRequest : BaseSingleFileRequest
+    public class FileExistsRequest : BaseSingleFileRequest<FileExistsRequest>
     {
     }
 }

--- a/src/Baseline.Filesystem/Requests/File/GetFileRequest.cs
+++ b/src/Baseline.Filesystem/Requests/File/GetFileRequest.cs
@@ -3,7 +3,7 @@ namespace Baseline.Filesystem
     /// <summary>
     /// Request used to retrieve information about a particular file.
     /// </summary>
-    public class GetFileRequest : BaseSingleFileRequest
+    public class GetFileRequest : BaseSingleFileRequest<GetFileRequest>
     {
     }
 }

--- a/src/Baseline.Filesystem/Requests/File/MoveFileRequest.cs
+++ b/src/Baseline.Filesystem/Requests/File/MoveFileRequest.cs
@@ -3,7 +3,7 @@ namespace Baseline.Filesystem
     /// <summary>
     /// Request for moving a file from a source path to a destination path within an adapter's storage.
     /// </summary>
-    public class MoveFileRequest : BaseSourceAndDestinationFileRequest
+    public class MoveFileRequest : BaseSourceAndDestinationFileRequest<MoveFileRequest>
     {
     }
 }

--- a/src/Baseline.Filesystem/Requests/File/ReadFileAsStringRequest.cs
+++ b/src/Baseline.Filesystem/Requests/File/ReadFileAsStringRequest.cs
@@ -3,7 +3,7 @@ namespace Baseline.Filesystem
     /// <summary>
     /// Request used to read a file's contents as a string.
     /// </summary>
-    public class ReadFileAsStringRequest : BaseSingleFileRequest
+    public class ReadFileAsStringRequest : BaseSingleFileRequest<ReadFileAsStringRequest>
     {
     }
 }

--- a/src/Baseline.Filesystem/Requests/File/TouchFileRequest.cs
+++ b/src/Baseline.Filesystem/Requests/File/TouchFileRequest.cs
@@ -3,7 +3,7 @@ namespace Baseline.Filesystem
     /// <summary>
     /// Request used to touch (create without content) a file.
     /// </summary>
-    public class TouchFileRequest : BaseSingleFileRequest
+    public class TouchFileRequest : BaseSingleFileRequest<TouchFileRequest>
     {
     }
 }

--- a/src/Baseline.Filesystem/Requests/File/WriteTextToFileRequest.cs
+++ b/src/Baseline.Filesystem/Requests/File/WriteTextToFileRequest.cs
@@ -20,9 +20,9 @@ namespace Baseline.Filesystem
         public string TextToWrite { get; set; }
 
         /// <inheritdoc />
-        internal override WriteTextToFileRequest CloneForPathUpdates()
+        internal override WriteTextToFileRequest ShallowClone()
         {
-            var clonedBase = base.CloneForPathUpdates();
+            var clonedBase = base.ShallowClone();
 
             clonedBase.ContentType = ContentType;
             clonedBase.TextToWrite = TextToWrite;

--- a/src/Baseline.Filesystem/Requests/File/WriteTextToFileRequest.cs
+++ b/src/Baseline.Filesystem/Requests/File/WriteTextToFileRequest.cs
@@ -3,7 +3,7 @@ namespace Baseline.Filesystem
     /// <summary>
     /// Request used to write text to a particular file path.
     /// </summary>
-    public class WriteTextToFileRequest : BaseSingleFileRequest
+    public class WriteTextToFileRequest : BaseSingleFileRequest<WriteTextToFileRequest>
     {
         /// <summary>
         /// Gets or sets the content (mime) type to set the file as. A jpeg file, for example, would be image/jpeg.
@@ -13,10 +13,21 @@ namespace Baseline.Filesystem
         public string ContentType { get; set; }
         
         /// <summary>
-        /// Gets or sets the text to write to the file defined by the <see cref="FilePath" /> property.
+        /// Gets or sets the text to write to the file defined by the FilePath property.
         ///
         /// NOTE: This property cannot be null (or it'll fail validation) but it can be empty or whitespace.
         /// </summary>
         public string TextToWrite { get; set; }
+
+        /// <inheritdoc />
+        internal override WriteTextToFileRequest CloneForPathUpdates()
+        {
+            var clonedBase = base.CloneForPathUpdates();
+
+            clonedBase.ContentType = ContentType;
+            clonedBase.TextToWrite = TextToWrite;
+
+            return clonedBase;
+        }
     }
 }

--- a/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Directories/CreateDirectoryTests.cs
+++ b/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Directories/CreateDirectoryTests.cs
@@ -43,7 +43,7 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Directories
             var response = await DirectoryManager.CreateAsync(new CreateDirectoryRequest {DirectoryPath = directory});
 
             await ExpectDirectoryToExistAsync(directory);
-            response.Directory.Path.Should().BeEquivalentTo(directory);
+            response.Directory.Path.Should().BeEquivalentTo(CombinedPathWithRootPathForAssertion(directory));
         }
     }
 }

--- a/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Files/GetFileTests.cs
+++ b/test/Baseline.Filesystem.Tests.Adapters.S3/Integration/Files/GetFileTests.cs
@@ -36,7 +36,7 @@ namespace Baseline.Filesystem.Tests.Adapters.S3.Integration.Files
             await CreateFileAndWriteTextAsync(path);
 
             var response = await FileManager.GetAsync(new GetFileRequest {FilePath = path});
-            response.File.Path.Should().Be(path);
+            response.File.Path.Should().BeEquivalentTo(CombinedPathWithRootPathForAssertion(path));
         }
     }
 }

--- a/test/Baseline.Filesystem.Tests/AdapterManagerTests/GetTests.cs
+++ b/test/Baseline.Filesystem.Tests/AdapterManagerTests/GetTests.cs
@@ -17,7 +17,11 @@ namespace Baseline.Filesystem.Tests.AdapterManagerTests
         [Fact]
         public void It_Returns_The_Adapter_When_An_Adapter_With_The_Exact_Name_Has_Been_Registered()
         {
-            AdapterManager.Register(new SuccessfulOutcomeAdapter(), "mySpecificNaming-CONVENTION");
+            AdapterManager.Register(new AdapterRegistration 
+            {
+                    Adapter = new SuccessfulOutcomeAdapter(), 
+                    Name = "mySpecificNaming-CONVENTION"
+            });
             var adapter = AdapterManager.Get("mySpecificNaming-CONVENTION");
             adapter.Should().NotBeNull();
         }
@@ -25,7 +29,11 @@ namespace Baseline.Filesystem.Tests.AdapterManagerTests
         [Fact]
         public void It_Returns_The_Adapter_When_An_Adapter_With_A_Normalised_Version_Of_The_Name_Has_Been_Registered()
         {
-            AdapterManager.Register(new SuccessfulOutcomeAdapter(), "my-specific-naming-convention");
+            AdapterManager.Register(new AdapterRegistration
+            {
+                Adapter = new SuccessfulOutcomeAdapter(),
+                Name = "my-specific-naming-convention"
+            });
             var adapter = AdapterManager.Get("MY-SpeCifIc-NAMING-convention");
             adapter.Should().NotBeNull();
         }

--- a/test/Baseline.Filesystem.Tests/AdapterManagerTests/RegisterTests.cs
+++ b/test/Baseline.Filesystem.Tests/AdapterManagerTests/RegisterTests.cs
@@ -10,7 +10,11 @@ namespace Baseline.Filesystem.Tests.AdapterManagerTests
         [Fact]
         public void It_Registers_An_Adapter_With_A_Normalised_Name()
         {
-            AdapterManager.Register(new SuccessfulOutcomeAdapter(), "my-NAMIng-ConVentION");
+            AdapterManager.Register(new AdapterRegistration
+            {
+                Adapter = new SuccessfulOutcomeAdapter(),
+                Name = "my-NAMIng-ConVentION"
+            });
             var result = AdapterManager.Get("my-naming-convention");
             result.Should().NotBeNull();
         }
@@ -18,15 +22,23 @@ namespace Baseline.Filesystem.Tests.AdapterManagerTests
         [Fact]
         public void It_Throws_An_Exception_When_An_Adapter_Is_Already_Registered_With_That_Name()
         {
-            AdapterManager.Register(new SuccessfulOutcomeAdapter(), "my-NAMING-convENTION");
-            Action func = () => AdapterManager.Register(new SuccessfulOutcomeAdapter(), "my-naming-convention");
+            AdapterManager.Register(new AdapterRegistration
+            {
+                Adapter = new SuccessfulOutcomeAdapter(),
+                Name = "my-NAMIng-ConVentION"
+            });
+            Action func = () => AdapterManager.Register(new AdapterRegistration
+            {
+                Adapter = new SuccessfulOutcomeAdapter(),
+                Name = "my-naming-convention"
+            });
             func.Should().ThrowExactly<AdapterAlreadyRegisteredException>();
         }
 
         [Fact]
         public void It_Registers_With_A_Default_Adapter_Name_If_One_Is_Not_Specified()
         {
-            AdapterManager.Register(new SuccessfulOutcomeAdapter());
+            AdapterManager.Register(new AdapterRegistration { Adapter = new SuccessfulOutcomeAdapter() });
             var result = AdapterManager.Get("default");
             result.Should().NotBeNull();
         }

--- a/test/Baseline.Filesystem.Tests/BaseManagerUsageTest.cs
+++ b/test/Baseline.Filesystem.Tests/BaseManagerUsageTest.cs
@@ -4,18 +4,27 @@ namespace Baseline.Filesystem.Tests
 {
     public abstract class BaseManagerUsageTest
     {
-        protected Mock<IAdapter> Adapter { get;  }
-        protected IAdapterManager AdapterManager { get;  }
-        protected IFileManager FileManager { get;  }
-        protected IDirectoryManager DirectoryManager { get;  }
+        protected Mock<IAdapter> Adapter { get; set; }
+        protected IAdapterManager AdapterManager { get; set; }
+        protected IFileManager FileManager { get; set; }
+        protected IDirectoryManager DirectoryManager { get; set; }
 
         protected BaseManagerUsageTest()
+        {
+            Reconfigure();
+        }
+
+        protected void Reconfigure(bool useRootPath = false)
         {
             Adapter = new Mock<IAdapter>();
             AdapterManager = new AdapterManager();
             DirectoryManager = new DirectoryManager(AdapterManager);
             FileManager = new FileManager(AdapterManager);
-            AdapterManager.Register(new AdapterRegistration { Adapter = Adapter.Object});
+            AdapterManager.Register(new AdapterRegistration
+            {
+                Adapter = Adapter.Object,
+                RootPath = useRootPath ? "root/".AsBaselineFilesystemPath() : null
+            });
         }
     }
 }

--- a/test/Baseline.Filesystem.Tests/BaseManagerUsageTest.cs
+++ b/test/Baseline.Filesystem.Tests/BaseManagerUsageTest.cs
@@ -1,4 +1,3 @@
-using Baseline.Filesystem.Internal.Contracts;
 using Moq;
 
 namespace Baseline.Filesystem.Tests
@@ -16,7 +15,7 @@ namespace Baseline.Filesystem.Tests
             AdapterManager = new AdapterManager();
             DirectoryManager = new DirectoryManager(AdapterManager);
             FileManager = new FileManager(AdapterManager);
-            AdapterManager.Register(Adapter.Object);
+            AdapterManager.Register(new AdapterRegistration { Adapter = Adapter.Object});
         }
     }
 }

--- a/test/Baseline.Filesystem.Tests/Fixtures/SuccessfulOutcomeAdapter.cs
+++ b/test/Baseline.Filesystem.Tests/Fixtures/SuccessfulOutcomeAdapter.cs
@@ -1,6 +1,5 @@
 using System.Threading;
 using System.Threading.Tasks;
-using Baseline.Filesystem.Internal.Contracts;
 
 namespace Baseline.Filesystem.Tests.Fixtures
 {

--- a/test/Baseline.Filesystem.Tests/GeneralTests.cs
+++ b/test/Baseline.Filesystem.Tests/GeneralTests.cs
@@ -17,7 +17,7 @@ namespace Baseline.Filesystem.Tests
                 .Setup(x => x.GetFileAsync(It.IsAny<GetFileRequest>(), CancellationToken.None))
                 .ThrowsAsync(new ExternalException());
             
-            Func<Task> func = async () => await FileManager.GetAsync(
+            Func<Task> act = async () => await FileManager.GetAsync(
                 new GetFileRequest
                 {
                     FilePath = "abc".AsBaselineFilesystemPath(),
@@ -26,11 +26,39 @@ namespace Baseline.Filesystem.Tests
                 CancellationToken.None
             );
             
-            await func
+            await act
                 .Should()
                 .ThrowExactlyAsync<AdapterProviderOperationException>()
                 .WithMessage("Unhandled exception thrown from adapter (default), potentially whilst communicating with " +
                              "its API. See the inner exception for details.");
+        }
+
+        [Fact]
+        public async Task It_Clones_The_Request_Passed_In_And_Does_Not_Modify_The_Original_Request()
+        {
+            Reconfigure(true);
+
+            var filePath = "abc".AsBaselineFilesystemPath();
+
+            var request = new FileExistsRequest
+            {
+                FilePath = filePath
+            };
+
+            Adapter
+                .Setup(x => 
+                    x.FileExistsAsync(
+                        It.Is<FileExistsRequest>(p => p.FilePath.OriginalPath == $"root/{filePath.OriginalPath}"), 
+                        It.IsAny<CancellationToken>()
+                    )
+                )
+                .ReturnsAsync(true)
+                .Verifiable();
+
+            await FileManager.ExistsAsync(request);
+
+            Adapter.Verify();
+            request.FilePath.Should().Be(filePath);
         }
     }
 }


### PR DESCRIPTION
Moved the path and root path combination out of the adapter and into the
top level managers.
    
Implemented a nice way to clone and update paths for requests.
    
Modified the tests to cater for this new way of doing things.
    
Moved some namespaces around that weren't in the correct place.

Added a test around how request objects are cloned and modified when the adapter registration contains a root path.

Closes #3 

